### PR TITLE
feat(WebsocketServer): Implement heartbeating

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Added metrics for:
 - input_frames
 - dropped_frames
 - decoded_frames
+- websocket_latency
 
 All metrics have labels based on player name and user email that is using this instance.
 

--- a/src/server/services/PromMetrics.ts
+++ b/src/server/services/PromMetrics.ts
@@ -34,4 +34,18 @@ const webSocketConnections = new promClient.Gauge({
     labelNames: ['user_ldap'],
 });
 
-export { decodedFramesGauge, droppedFramesGauge, inputBytesGauge, inputFramesGauge, webSocketConnections, playerNames };
+const webSocketLatency = new promClient.Histogram({
+    name: 'scrcpy_ws_latency',
+    help: 'Records the latency of WebSocket connections in milliseconds',
+    labelNames: ['user_ldap'],
+});
+
+export {
+    decodedFramesGauge,
+    droppedFramesGauge,
+    inputBytesGauge,
+    inputFramesGauge,
+    webSocketConnections,
+    playerNames,
+    webSocketLatency,
+};

--- a/src/server/services/WebSocketServer.ts
+++ b/src/server/services/WebSocketServer.ts
@@ -10,10 +10,13 @@ import {
     droppedFramesGauge,
     webSocketConnections,
     playerNames,
+    webSocketLatency,
 } from './PromMetrics';
 import { IncomingMessage } from 'http';
 import { ACTION } from '../../common/Action';
 import bunyan from 'bunyan';
+
+const HEARTBEAT_INTERVAL = 60_000;
 
 export class WebSocketServer implements Service {
     private static instance?: WebSocketServer;
@@ -21,6 +24,7 @@ export class WebSocketServer implements Service {
     private servers: WSServer[] = [];
     private mwFactories: Set<MwFactory> = new Set();
     private AUTH_EMAIL_HEADER = 'x-goog-authenticated-user-email';
+    private lastHeartbeatAt = new Map<WS, number>(); // Stores timestamp of when the last ping was acked
 
     protected constructor() {
         // nothing here
@@ -90,6 +94,67 @@ export class WebSocketServer implements Service {
         });
     }
 
+    private handleAdbProxy(user_ldap: string, action: string, ws: WS) {
+        webSocketConnections.labels(user_ldap).inc();
+
+        // Ensure we only perform close logic once to avoid double decrementing metrics
+        let closed = false;
+        const handleClose = () => {
+            if (closed) return;
+
+            WebSocketServer.logger.debug({ user_ldap, action }, 'Handling close logic');
+            webSocketConnections.labels(user_ldap).dec();
+            clearInterval(heartbeatInterval);
+            closed = true;
+
+            setImmediate(() => {
+                // Clean up last heartbeat timestamp asynchronously to flush any pending pong events
+                this.lastHeartbeatAt.delete(ws);
+            });
+        };
+
+        const heartbeatInterval = setInterval(() => {
+            const now = Date.now();
+            let lastAckAt = this.lastHeartbeatAt.get(ws);
+
+            // Initialize first ack for new connections
+            if (!lastAckAt) {
+                lastAckAt = Date.now();
+                this.lastHeartbeatAt.set(ws, lastAckAt);
+            }
+
+            // Connections are considered unresponsive if we miss three consecutive heartbeats
+            // i.e. the last pong we received is over 3 heartbeat intervals ago
+            const unresponsive = now - lastAckAt > HEARTBEAT_INTERVAL * 3;
+            if (unresponsive) {
+                WebSocketServer.logger.debug({ user_ldap, action, now, lastAckAt }, 'Closing due to missed heartbeat');
+                handleClose();
+                ws.close(4003, 'Heartbeat timeout');
+            } else {
+                WebSocketServer.logger.debug({ user_ldap, action }, 'Sending ping');
+                ws.ping(now.toString());
+            }
+        }, HEARTBEAT_INTERVAL);
+
+        ws.on('pong', (data) => {
+            WebSocketServer.logger.debug({ user_ldap, action }, 'Received heartbeat ack');
+
+            // Update last heartbeat at
+            const now = Date.now();
+            this.lastHeartbeatAt.set(ws, now);
+
+            // Record latency metric
+            const pingTimestamp = Number(data.toString());
+            const diff = now - pingTimestamp;
+            webSocketLatency.labels(user_ldap).observe(diff);
+        });
+
+        ws.on('close', () => {
+            WebSocketServer.logger.info({ user_ldap, action }, 'WebSocket close request');
+            handleClose();
+        });
+    }
+
     public attachToServer(item: ServerAndPort): WSServer {
         const { server, port } = item;
         const TAG = `WebSocket Server {tcp:${port}}`;
@@ -123,12 +188,9 @@ export class WebSocketServer implements Service {
             const action = url.searchParams.get('action') || '';
             let processed = false;
             WebSocketServer.logger.info({ user_ldap, action }, 'WebSocket request');
+
             if (action === ACTION.PROXY_ADB) {
-                webSocketConnections.labels(user_ldap).inc();
-                ws.on('close', () => {
-                    WebSocketServer.logger.info({ user_ldap, action }, 'WebSocket close request');
-                    webSocketConnections.labels(user_ldap).dec();
-                });
+                this.handleAdbProxy(user_ldap, action, ws);
             }
 
             for (const mwFactory of this.mwFactories.values()) {


### PR DESCRIPTION
### Test plan
1. Set `HEARTBEAT_INTERVAL` to 1 second
2. Opened a connection
3. Turned on airplane mode
4. Observed three outgoing pings without acks
5. Observed close logic on the third unacked ping
```
2024-04-16T14:35:10.924Z "Sending ping"
2024-04-16T14:35:10.934Z "Received heartbeat ack"
2024-04-16T14:35:11.925Z "Sending ping"
2024-04-16T14:35:11.936Z "Received heartbeat ack"
2024-04-16T14:35:12.926Z "Sending ping"
2024-04-16T14:35:12.939Z "Received heartbeat ack"
2024-04-16T14:35:13.927Z "Sending ping"
2024-04-16T14:35:13.938Z "Received heartbeat ack"
-- turned off wifi
2024-04-16T14:35:14.926Z "Sending ping"
2024-04-16T14:35:15.927Z "Sending ping"
2024-04-16T14:35:16.927Z "Sending ping"
2024-04-16T14:35:17.927Z "Closing due to missed heartbeat" { "now":1713278117927, "lastAckAt":1713278113938 }
2024-04-16T14:35:17.927Z "Handling close logic"
2024-04-16T14:35:42.044Z "WebSocket close request"
```
