### PR TITLE
fix(device): disable key forwarding if player is unfocused

### DIFF
--- a/src/app/googDevice/KeyInputHandler.ts
+++ b/src/app/googDevice/KeyInputHandler.ts
@@ -1,5 +1,6 @@
 import { KeyCodeControlMessage } from '../controlMessage/KeyCodeControlMessage';
 import KeyEvent from './android/KeyEvent';
+import { ConfigureScrcpy } from './client/ConfigureScrcpy';
 import { KeyToCodeMap } from './KeyToCodeMap';
 
 export interface KeyEventListener {
@@ -9,7 +10,13 @@ export interface KeyEventListener {
 export class KeyInputHandler {
     private static readonly repeatCounter: Map<number, number> = new Map();
     private static readonly listeners: Set<KeyEventListener> = new Set();
+
     private static handler = (event: Event): void => {
+        const isFocused = ConfigureScrcpy.streamClientScrcpy?.player?.isFocused ?? false;
+        if (!isFocused) {
+            return;
+        }
+
         const keyboardEvent = event as KeyboardEvent;
         const keyCode = KeyToCodeMap.get(keyboardEvent.code);
         if (!keyCode) {

--- a/src/app/googDevice/client/ConfigureScrcpy.ts
+++ b/src/app/googDevice/client/ConfigureScrcpy.ts
@@ -50,7 +50,7 @@ export class ConfigureScrcpy extends BaseClient<ParamsStreamScrcpy, ConfigureScr
     private dialogContainer?: HTMLElement;
     private statusText = '';
     private connectionCount = 0;
-    private static streamClientScrcpy?: StreamClientScrcpy;
+    public static streamClientScrcpy?: StreamClientScrcpy;
     private playerOptionMapping: { [key: string]: number } = {};
     private hidden = true;
     private restartTCPButton?: HTMLButtonElement;

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -59,7 +59,7 @@ export class StreamClientScrcpy
     private requestedVideoSettings?: VideoSettings;
     private touchHandler?: FeaturedInteractionHandler;
     private moreBox?: GoogMoreBox;
-    private player?: BasePlayer;
+    public player?: BasePlayer;
     private filePushHandler?: FilePushHandler;
     private fitToScreen?: boolean;
     private metricsWs?: WebSocket;

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -86,7 +86,7 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
     public readonly resizeVideoToBounds: boolean = false;
     protected videoHeight = -1;
     protected videoWidth = -1;
-
+    public isFocused: boolean;
     public static storageKeyPrefix = 'BaseDecoder';
     public static playerFullName = 'BasePlayer';
     public static playerCodeName = 'baseplayer';
@@ -112,14 +112,22 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
         protected tag: HTMLElement = document.createElement('div'),
     ) {
         super();
+
+        // Create touchable canvas
         this.touchableCanvas = document.createElement('canvas');
         this.touchableCanvas.setAttribute('willReadFrequently', 'true');
         this.touchableCanvas.className = 'touch-layer';
         this.touchableCanvas.oncontextmenu = function (event: MouseEvent): void {
             event.preventDefault();
         };
+
+        // Set video settings
         const preferred = this.getPreferredVideoSetting();
         this.videoSettings = BasePlayer.getVideoSettingFromStorage(preferred, this.storageKeyPrefix, udid, displayInfo);
+
+        // Set up focus logic
+        this.isFocused = false;
+        document.body.addEventListener('click', this.onClick.bind(this));
     }
 
     protected calculateScreenInfoForBounds(videoWidth: number, videoHeight: number): void {
@@ -524,6 +532,13 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
             ctx.fillText(text, p, y - p - line * (height + p));
         });
         ctx.restore();
+    }
+
+    private onClick(event: MouseEvent): void {
+        const focused = event.target === this.touchableCanvas;
+
+        this.isFocused = focused;
+        this.touchableCanvas.classList.toggle('focused', focused);
     }
 
     public setShowQualityStats(value: boolean): void {

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -96,11 +96,16 @@ body.stream {
     z-index: 6;
 }
 
+.touch-layer.focused {
+    box-shadow: 0 0 5px 5px var(--device-border-color);
+}
+
 .video {
     float: right;
     max-height: 100%;
     max-width: 100%;
     background-color: #000000;
+    margin: 5px;
 }
 
 


### PR DESCRIPTION
### Reproduction
1. Open scrcpy UI from devpod central
2. Observe that key bindings (e.g. ⌘+R to reload) are consumed by the emulator
3. Copy something to your clipboard (e.g. `https://google.com`)
4. Attempt to paste the link into the "Install Apps" textfield
5. Observe that the link is instead pasted into the emulator

### Test plan
1. Open scrcpy UI locally
2. Observe that key bindings (e.g. ⌘+R to reload) work
3. Copy something to your clipboard (e.g. `https://google.com`)
4. Attempt to paste the link into the "Install Apps" textfield
5. Observe that the link is correctly pasted into the "Install Apps" textfield, and nothing is sent to the emulator
6. Focus the emulator window and paste the link again
7. Observe that the link is pasted into the emulator window