### PR TITLE
feat(scrcpy): Implement pop out player

### DIFF
--- a/src/app/CurrentWindow.ts
+++ b/src/app/CurrentWindow.ts
@@ -1,0 +1,52 @@
+/**
+ * A stateless helper class that wraps a `window` object for context-agnostic (iframe, PIP, etc) operations
+ */
+export class CurrentWindow {
+    /** The main browser window */
+    public static main = new CurrentWindow(window);
+
+    /** The popped out PIP window, if there is one */
+    public static get pipWindow(): CurrentWindow | null {
+        return documentPictureInPicture.window && new CurrentWindow(documentPictureInPicture.window);
+    }
+
+    public document: Document;
+
+    constructor(public currentWindow: typeof window) {
+        this.document = currentWindow.document;
+    }
+
+    /**
+     * Copies stylesheets from the main window onto this window
+     */
+    public copyStylesheets(): void {
+        const source = CurrentWindow.main.document;
+        const target = this.document;
+
+        for (const styleSheet of Array.from(source.styleSheets)) {
+            const style = target.createElement('style');
+            const cssRules = Array.from(styleSheet.cssRules)
+                .map((rule) => rule.cssText)
+                .join('');
+
+            style.textContent = cssRules;
+            target.head.appendChild(style);
+        }
+    }
+
+    /**
+     * Checks if a value is an instance of a class in the current window context
+     * This is needed because each window context has it's own instances:
+     * $('iframe').contentWindow.window.MouseEvent != window.MouseEvent
+     *
+     * @param value The value to evaluate instanceness of (e.g. `value instanceof RHS`)
+     * @param key The string name of the class to check against (e.g. `'MouseEvent'`)
+     */
+    public instanceOf<T extends keyof typeof globalThis>(
+        value: unknown,
+        key: T,
+    ): value is InstanceType<typeof globalThis[T]> {
+        const klass = this.currentWindow[key];
+        return typeof klass === 'function' && value instanceof klass;
+    }
+}

--- a/src/app/CurrentWindow.ts
+++ b/src/app/CurrentWindow.ts
@@ -35,6 +35,18 @@ export class CurrentWindow {
     }
 
     /**
+     * Wrapper around `window.resizeTo` that takes the outer window padding into account
+     * @param width The target innerHeight of the window
+     * @param height The target innerWidth of the window
+     */
+    public resizeInner(width: number, height: number): void {
+        const deltaX = this.currentWindow.outerWidth - this.currentWindow.innerWidth;
+        const deltaY = this.currentWindow.outerHeight - this.currentWindow.innerHeight;
+
+        this.currentWindow.resizeTo(width + deltaX, height + deltaY);
+    }
+
+    /**
      * Checks if a value is an instance of a class in the current window context
      * This is needed because each window context has it's own instances:
      * $('iframe').contentWindow.window.MouseEvent != window.MouseEvent

--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -216,4 +216,20 @@ export default class Util {
     static setImmediate(fn: () => any): void {
         Promise.resolve().then(fn);
     }
+
+    /**
+     * Returns a promise that resolves when the given condition passes
+     * @param condition An arrow function describing the condition to evaluate
+     * @param ms The interval at which to evaluate the condition
+     */
+    static waitFor(condition: () => Promise<unknown> | unknown, ms = 10): Promise<void> {
+        return new Promise((resolve) => {
+            const interval = setInterval(async () => {
+                if (await condition()) {
+                    clearInterval(interval);
+                    resolve();
+                }
+            }, ms);
+        });
+    }
 }

--- a/src/app/googDevice/KeyInputHandler.ts
+++ b/src/app/googDevice/KeyInputHandler.ts
@@ -1,4 +1,5 @@
 import { KeyCodeControlMessage } from '../controlMessage/KeyCodeControlMessage';
+import { CurrentWindow } from '../CurrentWindow';
 import KeyEvent from './android/KeyEvent';
 import { ConfigureScrcpy } from './client/ConfigureScrcpy';
 import { KeyToCodeMap } from './KeyToCodeMap';
@@ -63,24 +64,15 @@ export class KeyInputHandler {
         event.preventDefault();
     };
 
-    private static attachListeners(): void {
-        document.body.addEventListener('keydown', this.handler);
-        document.body.addEventListener('keyup', this.handler);
-    }
-    private static detachListeners(): void {
-        document.body.removeEventListener('keydown', this.handler);
-        document.body.removeEventListener('keyup', this.handler);
-    }
-    public static addEventListener(listener: KeyEventListener): void {
-        if (!this.listeners.size) {
-            this.attachListeners();
-        }
+    public static addEventListener(currentWindow: CurrentWindow, listener: KeyEventListener): void {
         this.listeners.add(listener);
+        currentWindow.document.body.addEventListener('keydown', this.handler);
+        currentWindow.document.body.addEventListener('keyup', this.handler);
     }
-    public static removeEventListener(listener: KeyEventListener): void {
+
+    public static removeEventListener(currentWindow: CurrentWindow, listener: KeyEventListener): void {
         this.listeners.delete(listener);
-        if (!this.listeners.size) {
-            this.detachListeners();
-        }
+        currentWindow.document.body.removeEventListener('keydown', this.handler);
+        currentWindow.document.body.removeEventListener('keyup', this.handler);
     }
 }

--- a/src/app/googDevice/toolbox/GoogToolBox.ts
+++ b/src/app/googDevice/toolbox/GoogToolBox.ts
@@ -7,6 +7,7 @@ import { ToolBoxElement } from '../../toolbox/ToolBoxElement';
 import { ToolBoxCheckbox } from '../../toolbox/ToolBoxCheckbox';
 import { StreamClientScrcpy } from '../client/StreamClientScrcpy';
 import { BasePlayer } from '../../player/BasePlayer';
+import { ConfigureScrcpy } from '../client/ConfigureScrcpy';
 
 const BUTTONS = [
     {
@@ -94,6 +95,13 @@ export class GoogToolBox extends ToolBox {
             client.setHandleKeyboardEvents(element.checked);
         });
         elements.push(keyboard);
+
+        const popout = new ToolBoxCheckbox('Pop out', SvgImage.Icon.POP_OUT, 'popout', undefined, false);
+        popout.addEventListener('click', (_, el) => {
+            const element = el.getElement();
+            ConfigureScrcpy.streamClientScrcpy?.onPopOutClick(element.checked);
+        });
+        elements.push(popout);
 
         if (moreBox) {
             const displayId = player.getVideoSettings().displayId;

--- a/src/app/interactionHandler/FeaturedInteractionHandler.ts
+++ b/src/app/interactionHandler/FeaturedInteractionHandler.ts
@@ -5,6 +5,7 @@ import { TouchControlMessage } from '../controlMessage/TouchControlMessage';
 import MotionEvent from '../MotionEvent';
 import ScreenInfo from '../ScreenInfo';
 import { ScrollControlMessage } from '../controlMessage/ScrollControlMessage';
+import { CurrentWindow } from '../CurrentWindow';
 
 const TAG = '[FeaturedTouchHandler]';
 
@@ -29,8 +30,17 @@ export class FeaturedInteractionHandler extends InteractionHandler {
     private readonly storedFromTouchEvent = new Map<number, TouchControlMessage>();
     private lastScrollEvent?: { time: number; hScroll: number; vScroll: number };
 
-    constructor(player: BasePlayer, public readonly listener: InteractionHandlerListener) {
-        super(player, FeaturedInteractionHandler.touchEventsNames, FeaturedInteractionHandler.keyEventsNames);
+    constructor(
+        player: BasePlayer,
+        public readonly listener: InteractionHandlerListener,
+        private currentWindow: CurrentWindow,
+    ) {
+        super(
+            player,
+            FeaturedInteractionHandler.touchEventsNames,
+            FeaturedInteractionHandler.keyEventsNames,
+            currentWindow,
+        );
         this.tag.addEventListener('mouseleave', this.onMouseLeave);
         this.tag.addEventListener('mouseenter', this.onMouseEnter);
     }
@@ -62,11 +72,11 @@ export class FeaturedInteractionHandler extends InteractionHandler {
         }
         let messages: ControlMessage[];
         let storage: Map<number, TouchControlMessage>;
-        if (event instanceof MouseEvent) {
+        if (this.currentWindow.instanceOf(event, 'MouseEvent')) {
             if (event.target !== this.tag) {
                 return;
             }
-            if (window['WheelEvent'] && event instanceof WheelEvent) {
+            if (this.currentWindow.instanceOf(event, 'WheelEvent')) {
                 messages = this.buildScrollEvent(event, screenInfo);
             } else {
                 storage = this.storedFromMouseEvent;
@@ -75,7 +85,7 @@ export class FeaturedInteractionHandler extends InteractionHandler {
             if (this.over) {
                 this.lastPosition = event;
             }
-        } else if (window['TouchEvent'] && event instanceof TouchEvent) {
+        } else if (this.currentWindow.instanceOf(event, 'TouchEvent')) {
             // TODO: Research drag from out of the target inside it
             if (event.target !== this.tag) {
                 return;

--- a/src/app/interactionHandler/InteractionHandler.ts
+++ b/src/app/interactionHandler/InteractionHandler.ts
@@ -8,6 +8,7 @@ import TouchPointPNG from '../../public/images/multitouch/touch_point.png';
 import CenterPointPNG from '../../public/images/multitouch/center_point.png';
 import Util from '../Util';
 import { BasePlayer } from '../player/BasePlayer';
+import { CurrentWindow } from '../CurrentWindow';
 
 interface Touch {
     action: number;
@@ -87,22 +88,23 @@ export abstract class InteractionHandler {
         public readonly player: BasePlayer,
         public readonly touchEventsNames: InteractionEvents[],
         public readonly keyEventsNames: KeyEventNames[],
+        currentWindow: CurrentWindow = CurrentWindow.main,
     ) {
         this.tag = player.getTouchableElement();
         this.ctx = this.tag.getContext('2d', { willReadFrequently: true });
         InteractionHandler.loadImages();
-        InteractionHandler.bindGlobalListeners(this);
+        InteractionHandler.bindGlobalListeners(this, currentWindow.document);
     }
 
     protected abstract onInteraction(event: MouseEvent | TouchEvent): void;
     protected abstract onKey(event: KeyboardEvent): void;
 
-    protected static bindGlobalListeners(interactionHandler: InteractionHandler): void {
+    protected static bindGlobalListeners(interactionHandler: InteractionHandler, currentDocument: Document): void {
         interactionHandler.touchEventsNames.forEach((eventName) => {
             let set: Set<InteractionHandler> | undefined = InteractionHandler.eventListeners.get(eventName);
             if (!set) {
                 set = new Set();
-                document.body.addEventListener(eventName, this.onInteractionEvent, InteractionHandler.options);
+                currentDocument.body.addEventListener(eventName, this.onInteractionEvent, InteractionHandler.options);
                 this.eventListeners.set(eventName, set);
             }
             set.add(interactionHandler);
@@ -111,7 +113,7 @@ export abstract class InteractionHandler {
             let set = InteractionHandler.eventListeners.get(eventName);
             if (!set) {
                 set = new Set();
-                document.body.addEventListener(eventName, this.onKeyEvent);
+                currentDocument.body.addEventListener(eventName, this.onKeyEvent);
                 this.eventListeners.set(eventName, set);
             }
             set.add(interactionHandler);

--- a/src/app/player/BasePlayer.ts
+++ b/src/app/player/BasePlayer.ts
@@ -6,6 +6,7 @@ import Util from '../Util';
 import { TypedEmitter } from '../../common/TypedEmitter';
 import { DisplayInfo } from '../DisplayInfo';
 import defaultVideoSettings from './defaultVideoSettings.json';
+import { CurrentWindow } from '../CurrentWindow';
 
 interface BitrateStat {
     timestamp: number;
@@ -86,7 +87,8 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
     public readonly resizeVideoToBounds: boolean = false;
     protected videoHeight = -1;
     protected videoWidth = -1;
-    public isFocused: boolean;
+    public isFocused = false;
+    private currentWindow?: CurrentWindow;
     public static storageKeyPrefix = 'BaseDecoder';
     public static playerFullName = 'BasePlayer';
     public static playerCodeName = 'baseplayer';
@@ -127,7 +129,17 @@ export abstract class BasePlayer extends TypedEmitter<PlayerEvents> {
 
         // Set up focus logic
         this.isFocused = false;
-        document.body.addEventListener('click', this.onClick.bind(this));
+        this.onClick = this.onClick.bind(this);
+    }
+
+    public setCurrentWindow(currentWindow: CurrentWindow): void {
+        // Remove the old click handler
+        this.currentWindow?.document.body.removeEventListener('click', this.onClick);
+
+        // Set up the new click handler
+        this.isFocused = false;
+        this.currentWindow = currentWindow;
+        currentWindow.document.body.addEventListener('click', this.onClick);
     }
 
     protected calculateScreenInfoForBounds(videoWidth: number, videoHeight: number): void {

--- a/src/app/ui/SvgImage.ts
+++ b/src/app/ui/SvgImage.ts
@@ -15,6 +15,7 @@ import MenuSVG from '../../public/images/buttons/menu.svg';
 import ArrowBackSVG from '../../public/images/buttons/arrow_back.svg';
 import ToggleOnSVG from '../../public/images/buttons/toggle_on.svg';
 import ToggleOffSVG from '../../public/images/buttons/toggle_off.svg';
+import PopOutSVG from '../../public/images/buttons/pop_out.svg';
 
 export enum Icon {
     BACK,
@@ -34,6 +35,7 @@ export enum Icon {
     ARROW_BACK,
     TOGGLE_ON,
     TOGGLE_OFF,
+    POP_OUT,
 }
 
 export default class SvgImage {
@@ -74,6 +76,8 @@ export default class SvgImage {
                 return ToggleOnSVG;
             case Icon.TOGGLE_OFF:
                 return ToggleOffSVG;
+            case Icon.POP_OUT:
+                return PopOutSVG;
             default:
                 return '';
         }

--- a/src/public/images/buttons/pop_out.svg
+++ b/src/public/images/buttons/pop_out.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <path fill="none" d="M0 0h24v24H0z"/>
+        <path fill-rule="nonzero" d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zM6.707 6.293l2.25 2.25L11 6.5V12H5.5l2.043-2.043-2.25-2.25 1.414-1.414z"/>
+    </g>
+</svg>

--- a/src/types/DocumentPictureInPicture.d.ts
+++ b/src/types/DocumentPictureInPicture.d.ts
@@ -1,0 +1,21 @@
+// Typings for the DocumentPictureInPicture API
+// Follows the WICG spec: https://wicg.github.io/document-picture-in-picture
+
+type GlobalWindow = typeof window;
+
+interface DocumentPictureInPictureOptions {
+    width?: number;
+    height?: number;
+    disallowReturnToOpener?: boolean;
+}
+
+declare class DocumentPictureInPicture extends EventTarget {
+    requestWindow(options?: DocumentPictureInPictureOptions): Promise<GlobalWindow>;
+    readonly window: GlobalWindow | null;
+}
+
+declare global {
+    const documentPictureInPicture: DocumentPictureInPicture;
+}
+
+export {};


### PR DESCRIPTION
# Summary
This PR implements a pop-out button that pops out the device element to a PIP (picture-in-picture) window, using the [`DocumentPictureInPicture`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentPictureInPicture) API. 

# Commits
- [`feat(app): add PIP typings, CurrentWindow wrapper`](https://github.com/PetrasRec/ws-scrcpy/commit/300dcba71643c97856b909b5555d680c240030c9)
  - `DocumentPictureInPicture.d.ts`: Because `DocumentPictureInPicture` is an experimental API, tslib has no typings for it, so we have to add our own
  - `CurrentWindow.ts`: This is an abstraction over window objects to make it easier to deal with different contexts, will also prove useful when we work with iframes in the future
- [`feat(icons): add PopOut icon`](https://github.com/PetrasRec/ws-scrcpy/commit/2948df853f88f0ec6e631609d668ebae69e32c50)
- [`refactor(googDevice): support window-agnostic contexts in key and interaction handlers`](https://github.com/PetrasRec/ws-scrcpy/commit/47465baf95e8846986f93096d7e7b30cc4592bec)
  - `KeyInputHandler.ts`: Refactored to attach the event listeners to a specific `CurrentWindow` instance, so we can attach and detach the listeners from the main window and the PIP window when the popout is toggled
  - `InteractionHandler.ts`: Same as key input handler, but for mouse interactions
  - `FeaturedInteractionHandler.ts`: Fixed to use `CurrentWindow#instanceOf` instead of the `instanceof` operator
- [`refactor(player): support switching window contexts`](https://github.com/PetrasRec/ws-scrcpy/commit/2535460772b4adbc946ce00093b046d6160b269b)
  - Similar to key input handler refactor, refactored `BasePlayer` to reattach event listeners across window contexts
- [`feat(util): Implement waitFor`](https://github.com/PetrasRec/ws-scrcpy/commit/8f58a0624b0360300b66c7352cce22436fa59cb2)
- [`feat(scrcpy): implement picture in picture API`](https://github.com/PetrasRec/ws-scrcpy/commit/72cbcb572b8449faf4be6d606b6e8f253d0aa111)
  - `GoogToolBox.ts`: Added the popout button
  - `StreamClientScrcpy.ts`
    - Core of the PIP implementation is implemented in `onPopOutClick()`, `openPIP()`, `closePIP()`
    - Refactored `setHandleKeyboardEvents()` and `setTouchListeners()` to detach and re-attach input handlers on the correct window
    - Refactored `onKeyEvent()` to be window-agnostic
    - Stored a reference to `GoogToolBox` so we can toggle the checked state of the popout button when the window is closed
- [`feat(pip): resize window on first click`](https://github.com/PetrasRec/ws-scrcpy/commit/29a8eb2354d87a579c414d58bc5798b2de7ad82c)
  - This is the ""fix"" for the screen resizing issue I mentioned, I realised today that it's not just small screens (e.g. 13" MBA) but also the 1440p displays at the office, not sure under which conditions Chrome decides to clamp the viewport. I don't love this solution of resizing on first click, but not aware of any other viable solutions at the moment.
# Test plan
https://github.com/PetrasRec/ws-scrcpy/assets/25572140/35b9ea60-617b-4e84-9e83-323a3a2a6c19

1. Click the "Pop Out" device button and observe that a PIP window opens and the device window is moved to this window
2. On a `2048x1152` display:
    -  Observe that due to [aspect ratio limitations](https://developer.mozilla.org/en-US/docs/Web/API/DocumentPictureInPicture/requestWindow#sect3), the inner player element is smaller than the PIP window, and the bottom of the player is cut off (00:04)
    - Observe the mitigation: clicking into the PIP window resizes the PIP window to fit the entire player (00:10)
3. Click the device buttons in the PIP window and observe that they work
4. Paste text into the main window (e.g. the "Install apps" tab) and observe that the clipboard focus still works
5. Close the PIP window in various ways (the dedicated "Return to tab" button, the "X" button, and ⌘+w) and observe that the key handlers still work
6. **Known bug**: Sometimes, when closing the PIP, the returned window in the main context displays a black screen (reproduced at 00:50). The issue resolves itself when the next frame is drawn (e.g. on a mouse interaction). 