### PR TITLE
feat(device): add "Renderer" field

### DIFF
--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -107,6 +107,8 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                         element.textContent = `${value} Mb`;
                     } else if (key === 'CpuLoadEstimate') {
                         element.textContent = `${value} cores`;
+                    } else if (key === 'Renderer') {
+                        element.textContent = value;
                     }
                 });
             }
@@ -374,6 +376,10 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
                 <div class="device-property">
                     CPU load (estimate):
                     <span class="device-value" id="CpuLoadEstimate"></span>
+                </div>
+                <div class="device-property">
+                    Renderer:
+                    <span class="device-value" id="Renderer"></span>
                 </div>
             </div>`.content;
         const services = divHtml.getElementById(servicesId);

--- a/src/server/goog-device/Device.ts
+++ b/src/server/goog-device/Device.ts
@@ -71,10 +71,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     private async updateChangingInfo() {
         if (this.connected) {
-            const uptime = await this.getEmulatorUptime();
-            const memoryUsage = await this.getEmulatorMemoryUsage();
-            const cpuLoadEstimate = await this.getCpuLoadEstimate();
-            const renderer = await this.getRenderer();
+            const [uptime, memoryUsage, cpuLoadEstimate, renderer] = await Promise.all([
+                this.getEmulatorUptime(),
+                this.getEmulatorMemoryUsage(),
+                this.getCpuLoadEstimate(),
+                this.getRenderer(),
+            ]);
 
             this.emit('updatePeriodically', {
                 EmulatorUptime: uptime,


### PR DESCRIPTION
## Context
We are rolling out GPU-accelerated emulators in some regions. Users should know whether their emulator is GPU-accelerated or not.

## Changes
- [`feat(device): add "Renderer" field`](https://github.com/PetrasRec/ws-scrcpy/commit/01e9fd8c40c83983ef8bc716be87026e36315193):
  - [`DeviceTracker.ts`](https://github.com/PetrasRec/ws-scrcpy/commit/01e9fd8c40c83983ef8bc716be87026e36315193#diff-b96503a8c6e36b0d00d33694c457aaef6537d55e0822dff4c3808c1984a0ac7f)
    - Added the `.device-property#Renderer` div
    - Added logic to the periodic update handler to re-render
  - [`Device.ts`](https://github.com/PetrasRec/ws-scrcpy/commit/01e9fd8c40c83983ef8bc716be87026e36315193#diff-d3d27db69acb9a55ebd5e85209dc3325a0658128bcae3fbec13c1f75bf078793):
    - Added `private async getRenderer()` to get a human-readable string of the renderer the emulator is using
    - Updated periodic emitter to fetch and emit it
- [`refactor(device): use Promise.all to fetch changing info
`](https://github.com/PetrasRec/ws-scrcpy/commit/ccf166d31e4b31e2f18866363a5a193b1568ec53)
  - [`Device.ts`](https://github.com/PetrasRec/ws-scrcpy/commit/ccf166d31e4b31e2f18866363a5a193b1568ec53#diff-d3d27db69acb9a55ebd5e85209dc3325a0658128bcae3fbec13c1f75bf078793): Refactored to execute adb commands in parallel
  
## Preview
### CPU
![image](https://github.com/PetrasRec/ws-scrcpy/assets/25572140/7e3e7680-27a6-4d52-ab2a-32361d71f8bd)

### GPU
![image](https://github.com/PetrasRec/ws-scrcpy/assets/25572140/2fb52a1d-cfbb-4028-af06-17a745e97f6c)

