### PR TITLE
feat(player): Raise bitrate to 4.0 MiB

### DIFF
--- a/src/app/player/defaultVideoSettings.json
+++ b/src/app/player/defaultVideoSettings.json
@@ -1,6 +1,6 @@
 {
     "lockedVideoOrientation": -1,
-    "bitrate": 524288,
+    "bitrate": 4194304,
     "maxFps": 30,
     "iFrameInterval": 5,
     "bounds": {


### PR DESCRIPTION
GPU emulators can handle more throughput, and this bitrate is still acceptable on CPU emulators