### PR TITLE
feat(device): create renderer gauge

### DIFF
--- a/src/server/goog-device/Device.ts
+++ b/src/server/goog-device/Device.ts
@@ -429,7 +429,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         });
     }
 
-    private async getRenderer(): Promise<{ type: string; device: string }> {
+    public async getRenderer(): Promise<{ type: string; device: string }> {
         const output = await this.runShellCommandAdbKit("dumpsys SurfaceFlinger | grep 'GLES:'");
         const [translator, driver] = output.split(', ').slice(1);
         const device = translator.match(/Translator \((.*)\)/)?.[1] ?? '';

--- a/src/server/goog-device/Device.ts
+++ b/src/server/goog-device/Device.ts
@@ -82,7 +82,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 EmulatorUptime: uptime,
                 MemoryUsage: memoryUsage,
                 CpuLoadEstimate: cpuLoadEstimate,
-                Renderer: renderer,
+                Renderer: `${renderer.type} (${renderer.device})`,
             });
         }
     }
@@ -429,16 +429,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
         });
     }
 
-    private async getRenderer(): Promise<string> {
+    private async getRenderer(): Promise<{ type: string; device: string }> {
         const output = await this.runShellCommandAdbKit("dumpsys SurfaceFlinger | grep 'GLES:'");
         const [translator, driver] = output.split(', ').slice(1);
         const device = translator.match(/Translator \((.*)\)/)?.[1] ?? '';
 
-        if (driver.includes('NVIDIA')) {
-            return `GPU (${device})`;
-        } else {
-            return `CPU (${device})`;
-        }
+        return {
+            type: driver.includes('NVIDIA') ? 'GPU' : 'CPU',
+            device,
+        };
     }
 
     private emitUpdate(setUpdateTime = true): void {

--- a/src/server/services/PromMetrics.ts
+++ b/src/server/services/PromMetrics.ts
@@ -4,6 +4,12 @@ const labels = ['player_name', 'user_ldap'];
 
 const playerNames = ['Broadway.js', 'H264 Converter', 'Tiny H264', 'WebCodecs'];
 
+export const renderersGauge = new promClient.Gauge({
+    name: 'scrcpy_emulator_renderers',
+    help: 'Gauge representing which renderer emulators are using',
+    labelNames: ['user_ldap', 'emulator_name', 'renderer_type', 'renderer_device'],
+});
+
 const decodedFramesGauge = new promClient.Gauge({
     name: 'scrcpy_decoded_frames',
     help: 'Number of decoded frames per second',


### PR DESCRIPTION
## Summary
We want to be able to track what type of renderer an emulator is currently using. This will end up being an instant metric with a table/counter, so we intentionally don't decrement the gauge when the client disconnects: Prometheus will remember the value as long as it's missing, and we're only setting it to a static `1`

## Test plan
Connected to emulator locally and checked metrics endpoint:
```
 % curl localhost:8000/metrics -s | grep scrcpy_emulator_renderers 
# HELP scrcpy_emulator_renderers Gauge representing which renderer emulators are using
# TYPE scrcpy_emulator_renderers gauge
scrcpy_emulator_renderers{
  user_ldap="localhost",
  emulator_name="zainali-devpod.android-emulator:5555",
  renderer_device="Google SwiftShader",
  renderer_type="CPU"
} 1
```