### PR TITLE
feat(scrcpy): add emulator health check endpoint

### DIFF
--- a/src/app/client/BaseDeviceTracker.ts
+++ b/src/app/client/BaseDeviceTracker.ts
@@ -178,6 +178,7 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE> ext
             devices = document.createElement('div');
             devices.id = id;
             devices.className = 'table-wrapper';
+            devices.style.maxWidth = '900px';
             document.body.appendChild(devices);
         }
         return devices;

--- a/src/app/googDevice/KeyInputHandler.ts
+++ b/src/app/googDevice/KeyInputHandler.ts
@@ -58,6 +58,7 @@ export class KeyInputHandler {
             repeatCount,
             metaState,
         );
+
         KeyInputHandler.listeners.forEach((listener) => {
             listener.onKeyEvent(controlMessage);
         });

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -502,6 +502,15 @@ export class StreamClientScrcpy
     }
 
     public onKeyEvent(event: KeyCodeControlMessage): void {
+        // Ignore left meta key (which is Cmd on macOS)
+        // While copy/pasting text this key goes to home screen. This is not expected behavior.
+        // This is probably set inside scrcpy image itself, but tested it against scrcpy cli and that key did nothing
+        // So for now will just ignore this key
+        // All emulator shortcuts with CMD key are combined with some other key
+        if (event.keycode === KeyEvent.KEYCODE_META_LEFT) {
+            return;
+        }
+
         if (event.metaState & KeyEvent.META_META_ON) {
             if (event.keycode === KeyEvent.KEYCODE_V) {
                 const sendClipboard = async () => {

--- a/src/server/goog-device/AdbUtils.ts
+++ b/src/server/goog-device/AdbUtils.ts
@@ -18,7 +18,6 @@ import fs from 'fs';
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import bunyan from 'bunyan';
-import { Device } from '@dead50f7/adbkit/lib/Device';
 
 type IncomingMessage = {
     statusCode?: number;

--- a/src/server/goog-device/AdbUtils.ts
+++ b/src/server/goog-device/AdbUtils.ts
@@ -372,7 +372,6 @@ export class AdbUtils {
         return props['ro.product.model'] || 'Unknown device';
     }
 
-
     public static async deviceHealthCheck(): Promise<void> {
         const client = AdbExtended.createClient();
         const devices = await client.listDevices();

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -95,6 +95,16 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                 res.end(await promClient.register.metrics());
             });
 
+            this.mainApp.get('/health', async (_, res) => {
+                AdbUtils.deviceHealthCheck()
+                    .then(() => {
+                        res.status(200).send('OK');
+                    })
+                    .catch((err: Error) => {
+                        res.status(503).send({ error: err.message });
+                    });
+            });
+
             this.mainApp.post('/restart-tcp', async (req) => {
                 // TCP connection for some reason gets corrupted after prolonged idling or after restart
                 // adb tcpip 5555 fixes this issue, for now providing temporary workaround

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -95,12 +95,15 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                 res.end(await promClient.register.metrics());
             });
 
+            // Define a new route for health check
             this.mainApp.get('/health', async (_, res) => {
                 AdbUtils.deviceHealthCheck()
                     .then(() => {
+                        HttpServer.logger.info({}, 'Health check OK');
                         res.status(200).send('OK');
                     })
                     .catch((err: Error) => {
+                        HttpServer.logger.info({ error: err?.message }, 'Health failed');
                         res.status(503).send({ error: err.message });
                     });
             });


### PR DESCRIPTION
A health check that will be used to determine if emulator is running.

To check if emulator is in a healthy state we will check 3 things:
1. adb connection is established with "device" type (other 2 types are "offline" or "unauthorized")
2. emulator init.svc.bootanim needs to be set to "stopped". In our case we run emulators with "-no-boot-anim" so it's very likely that it will always be equal to "stopped".
3. emulator sys.boot_completed is equal to 1