### PR TITLE
fix(scrcpy): bundle Leaflet CSS from npm instead of external CDN 

### DIFF
--- a/src/app/CurrentWindow.ts
+++ b/src/app/CurrentWindow.ts
@@ -27,10 +27,13 @@ export class CurrentWindow {
     public copyStylesheets(): void {
         const source = CurrentWindow.main.document;
         const target = this.document;
+        const currentOrigin = window.location.origin;
 
         for (const styleSheet of Array.from(source.styleSheets)) {
             try {
-                if (styleSheet.cssRules) {
+                const isSameOrigin = !styleSheet.href || new URL(styleSheet.href).origin === currentOrigin;
+
+                if (isSameOrigin && styleSheet.cssRules) {
                     const style = target.createElement('style');
                     const cssRules = Array.from(styleSheet.cssRules)
                         .map((rule) => rule.cssText)
@@ -40,11 +43,10 @@ export class CurrentWindow {
                     target.head.appendChild(style);
                 }
             } catch (error) {
-                console.warn('Skipping cross-origin stylesheet:', styleSheet.href, error);
+                console.warn('Skipping inaccessible stylesheet:', styleSheet.href, error);
             }
         }
     }
-
 
     /**
      * Wrapper around `window.resizeTo` that takes the outer window padding into account

--- a/src/app/CurrentWindow.ts
+++ b/src/app/CurrentWindow.ts
@@ -27,24 +27,15 @@ export class CurrentWindow {
     public copyStylesheets(): void {
         const source = CurrentWindow.main.document;
         const target = this.document;
-        const currentOrigin = window.location.origin;
 
         for (const styleSheet of Array.from(source.styleSheets)) {
-            try {
-                const isSameOrigin = !styleSheet.href || new URL(styleSheet.href).origin === currentOrigin;
+            const style = target.createElement('style');
+            const cssRules = Array.from(styleSheet.cssRules)
+                .map((rule) => rule.cssText)
+                .join('');
 
-                if (isSameOrigin && styleSheet.cssRules) {
-                    const style = target.createElement('style');
-                    const cssRules = Array.from(styleSheet.cssRules)
-                        .map((rule) => rule.cssText)
-                        .join('');
-
-                    style.textContent = cssRules;
-                    target.head.appendChild(style);
-                }
-            } catch (error) {
-                console.warn('Skipping inaccessible stylesheet:', styleSheet.href, error);
-            }
+            style.textContent = cssRules;
+            target.head.appendChild(style);
         }
     }
 

--- a/src/app/CurrentWindow.ts
+++ b/src/app/CurrentWindow.ts
@@ -29,15 +29,22 @@ export class CurrentWindow {
         const target = this.document;
 
         for (const styleSheet of Array.from(source.styleSheets)) {
-            const style = target.createElement('style');
-            const cssRules = Array.from(styleSheet.cssRules)
-                .map((rule) => rule.cssText)
-                .join('');
+            try {
+                if (styleSheet.cssRules) {
+                    const style = target.createElement('style');
+                    const cssRules = Array.from(styleSheet.cssRules)
+                        .map((rule) => rule.cssText)
+                        .join('');
 
-            style.textContent = cssRules;
-            target.head.appendChild(style);
+                    style.textContent = cssRules;
+                    target.head.appendChild(style);
+                }
+            } catch (error) {
+                console.warn('Skipping cross-origin stylesheet:', styleSheet.href, error);
+            }
         }
     }
+
 
     /**
      * Wrapper around `window.resizeTo` that takes the outer window padding into account

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -456,9 +456,12 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
     }
 
     private initMap(): void {
-        const map = L.map('map', { attributionControl: false }).setView([52.3676, 4.9041], 13); // Centered on Amsterdam
+        const map = L.map('map', { attributionControl: true }).setView([52.3676, 4.9041], 13); // Centered on Amsterdam
 
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+        }).addTo(map);
 
         let marker: L.Marker | null = null;
 

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -23,6 +23,15 @@ import moment from 'moment';
 import { Flipper } from './Flipper';
 import * as L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerRetina from 'leaflet/dist/images/marker-icon-2x.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+L.Icon.Default.mergeOptions({
+    iconRetinaUrl: markerRetina,
+    iconUrl: markerIcon,
+    shadowUrl: markerShadow,
+});
 
 type Field = keyof GoogDeviceDescriptor | ((descriptor: GoogDeviceDescriptor) => string);
 type DescriptionColumn = { title: string; field: Field };

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -27,6 +27,9 @@ import markerIcon from 'leaflet/dist/images/marker-icon.png';
 import markerRetina from 'leaflet/dist/images/marker-icon-2x.png';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
+// https://github.com/PaulLeCam/react-leaflet/issues/453
+// https://stackoverflow.com/questions/49441600/react-leaflet-marker-files-not-found
+// We need to override the default icon URLs to point to the correct location
 L.Icon.Default.mergeOptions({
     iconRetinaUrl: markerRetina,
     iconUrl: markerIcon,

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -459,8 +459,7 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         const map = L.map('map', { attributionControl: true }).setView([52.3676, 4.9041], 13); // Centered on Amsterdam
 
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution:
-                '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         }).addTo(map);
 
         let marker: L.Marker | null = null;

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -22,6 +22,7 @@ import { ParamsStreamScrcpy } from '../../../types/ParamsStreamScrcpy';
 import moment from 'moment';
 import { Flipper } from './Flipper';
 import * as L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 
 type Field = keyof GoogDeviceDescriptor | ((descriptor: GoogDeviceDescriptor) => string);
 type DescriptionColumn = { title: string; field: Field };

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -39,8 +39,6 @@
       text-align: left;
     }
   </style>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<link href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" rel="stylesheet"/>
 </head>
 <body>
   <div class="navbar-container">


### PR DESCRIPTION
When using external css files pop out emulators broke as it couldn't copy leaflet css due to cross origin. This uses the bundled leaflet css files.

For markers we need to create overrides, more info here:
https://github.com/PaulLeCam/react-leaflet/issues/453
https://stackoverflow.com/questions/49441600/react-leaflet-marker-files-not-found

<img width="738" alt="image" src="https://github.com/user-attachments/assets/b3465217-4d3b-4577-88e2-f0bf221d80ee" />

Also added contributors as per https://www.openstreetmap.org/copyright
